### PR TITLE
define_class_method was actually defining methods on Class

### DIFF
--- a/lib/freshbooks/base.rb
+++ b/lib/freshbooks/base.rb
@@ -88,10 +88,15 @@ module FreshBooks
       end
     end
     
-    def self.define_class_method(symbol, &block)
-      self.class.send(:define_method, symbol, &block)
+    def self.metaclass
+      class << self; self; end
     end
     
+    def self.define_class_method(symbol, &block)
+      metaclass.instance_eval do
+        define_method symbol, &block
+      end
+    end
     
     def self.actions(*operations)
       operations.each do |operation|
@@ -152,7 +157,7 @@ module FreshBooks
     
     def api_action(action_name)
       response = FreshBooks::Base.connection.call_api(
-        "#{self.class.api_class_name}.#{action_name}", 
+        "#{self.class.api_class_name}.#{action_name}",
         "#{self.class.api_class_name}_id" => primary_key_value)
       response.success?
     end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -98,12 +98,12 @@ class TestBase < Test::Unit::TestCase
   
   def test_can_handle_all_zero_updated_at
     xml = <<-END_XML
-      <my_client> 
-        <client_id>3</client_id> 
-        <first_name>Test</first_name> 
-        <last_name>User</last_name> 
-        <organization>User Testing</organization> 
-        <updated>0000-00-00 00:00:00</updated> 
+      <my_client>
+        <client_id>3</client_id>
+        <first_name>Test</first_name>
+        <last_name>User</last_name>
+        <organization>User Testing</organization>
+        <updated>0000-00-00 00:00:00</updated>
       </my_client>
     END_XML
     doc = REXML::Document.new(xml)
@@ -112,6 +112,10 @@ class TestBase < Test::Unit::TestCase
     assert_equal nil, item.updated
   end
   
+  def test_actions
+    assert FreshBooks::MyItem.respond_to?(:get)
+    assert !Class.new.respond_to?(:get)
+  end
 end
 
 module FreshBooks
@@ -127,6 +131,7 @@ module FreshBooks
       s.object :my_address
       s.array :my_lines
     end
+    actions :get
   end
 
   class MyClient < FreshBooks::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require File.dirname(__FILE__) + '/../lib/freshbooks'
 require 'stringio'
 require 'test/unit'
 require File.dirname(__FILE__) + '/mock_connection'
+require 'active_support/all'
 
 begin
   require 'mocha'


### PR DESCRIPTION
I refactored the code to use the metaclass per this blog post: http://ryanangilly.com/post/234897271/dynamically-adding-class-methods-in-ruby

It was showing up in an issue with mongoid, which defines a class level get method as well and they were colliding.
