### PR TITLE
The estimate number is not necessarily a numeric value

### DIFF
--- a/lib/freshbooks/estimate.rb
+++ b/lib/freshbooks/estimate.rb
@@ -1,10 +1,10 @@
 module FreshBooks
   class Estimate < FreshBooks::Base
     define_schema do |s|
-      s.string :estimate_id, :status, :date, :notes, :terms, :first_name
+      s.string :estimate_id, :status, :date, :notes, :terms, :first_name, :number
       s.string :last_name, :organization, :p_street1, :p_street2, :p_city
       s.string :p_state, :p_country, :p_code
-      s.fixnum :client_id, :po_number, :number
+      s.fixnum :client_id, :po_number
       s.float :discount, :amount
       s.array :lines
       s.object :links, :read_only => true


### PR DESCRIPTION
The estimate "number" field can be a string, so I changed the schema for estimates.
