### PR TITLE
Update account_url regex for older Freshbooks URLs

### DIFF
--- a/lib/freshbooks/connection.rb
+++ b/lib/freshbooks/connection.rb
@@ -21,7 +21,7 @@ module FreshBooks
     self.log_level = Logger::WARN
     
     def initialize(account_url, auth_token, request_headers = {}, options = {})
-      raise InvalidAccountUrlError.new unless account_url =~ /^[0-9a-zA-Z\-_]+\.freshbooks\.com$/
+      raise InvalidAccountUrlError.new unless account_url =~ /^[0-9a-zA-Z\-_]+\.(freshbooks|billingarm)\.com$/
       
       @account_url = account_url
       @auth_token = auth_token


### PR DESCRIPTION
Freshbooks accounts created years ago have "*.billingarm.com" URLs. This updates the account_url regex to support those.
